### PR TITLE
Add courses to app-drawer

### DIFF
--- a/src/courses/courses-card.html
+++ b/src/courses/courses-card.html
@@ -1,8 +1,8 @@
 <link rel="import" href="../../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../../bower_components/paper-card/paper-card.html">
+<link rel="import" href="../shared-styles.html">
 <link rel="import" href="../siren-entity-mixin.html">
 <link rel="import" href="enrollment-item.html">
-<link rel="import" href="../shared-styles.html">
 
 <dom-module id="d2l-courses-card">
 	<template>
@@ -37,7 +37,6 @@
 
 			static get properties() {
 				return {
-					entity: Object,
 					hasCourses: {
 						type: Boolean,
 						value: true

--- a/src/courses/courses-drawer.html
+++ b/src/courses/courses-drawer.html
@@ -1,0 +1,67 @@
+<link rel="import" href="../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../bower_components/paper-card/paper-card.html">
+<link rel="import" href="../shared-styles.html">
+<link rel="import" href="../siren-entity-mixin.html">
+<link rel="import" href="../siren-entity.html">
+<link rel="import" href="enrollment-item.html">
+
+<dom-module id="d2l-courses-drawer">
+	<template>
+		<style include="shared-styles">
+			:host {
+				display: block;
+			}
+		</style>
+		<d2l-siren-entity href="[[href]]" token="[[token]]" entity="{{rootEntity}}"></d2l-siren-entity>
+		<d2l-siren-entity href="[[userLink.href]]" token="[[token]]" entity="{{userEntity}}"></d2l-siren-entity>
+		<d2l-siren-entity href="[[myEnrollmentsLink.href]]" token="[[token]]" entity="{{myEnrollmentsEntity}}"></d2l-siren-entity>
+
+		<template is="dom-if" if="{{hasCourses}}">
+			<template is="dom-repeat" items="{{myEnrollmentsEntity.entities}}">
+				<d2l-enrollment-item href="[[item.href]]" token="{{token}}"></d2l-enrollment-item>
+			</template>
+		</template>
+		<template is="dom-if" if="{{!hasCourses}}">
+			<span>You have no courses</span>
+		</template>
+	</template>
+
+	<script>
+		/* @mixes SirenEntityMixin */
+		class CoursesDrawer extends SirenEntityMixin(Polymer.Element) {
+			static get is() { return 'd2l-courses-drawer'; }
+
+			static get properties() {
+				return {
+					hasCourses: {
+						type: Boolean,
+						value: true
+					},
+					rootEntity: Object,
+					userEntity: Object,
+					userLink: {
+						type: Object,
+						computed: '_getLinkByRel(entity, "https://api.brightspace.com/rels/whoami")'
+					},
+					myEnrollmentsEntity: Object,
+					myEnrollmentsLink: {
+						type: Object,
+						computed: '_getLinkByRel(userEntity, "https://api.brightspace.com/rels/my-enrollments")'
+					}
+				};
+			}
+
+			static get observers() {
+				return [
+					'_changed(myEnrollmentsEntity)'
+				];
+			}
+
+			_changed(myEnrollmentsEntity) {
+				this.hasCourses = myEnrollmentsEntity.entities && myEnrollmentsEntity.entities.length > 0;
+			}
+		}
+
+		window.customElements.define(CoursesDrawer.is, CoursesDrawer);
+	</script>
+</dom-module>

--- a/src/my-app-main-page.html
+++ b/src/my-app-main-page.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
-<link rel="import" href="courses/courses-card.html">
+<link rel="import" href="../bower_components/paper-card/paper-card.html">
 <link rel="import" href="shared-styles.html">
 <link rel="import" href="siren-entity.html">
 <link rel="import" href="siren-entity-mixin.html">
@@ -28,15 +28,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 				align-items: stretch;
 			}
 
-			.courses-item {
-				max-width: 1200px;
-				width: calc(20%);
-				padding: 20px 0px 0px 20px;
-				margin-left: 0; margin-right: auto;
-			}
-
 			.calendar {
-				width: calc(80% - 50px);
+				width: 100%;
 				margin: 20px 20px 0px 10px;
 				height: 800px;
 			}
@@ -44,7 +37,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 		</style>
 		<d2l-siren-entity href="{{whoami.href}}" token="{{token}}" entity="{{userEntity}}"></d2l-siren-entity>
 		<div class="layout">
-			<d2l-courses-card href="{{myEnrollments.href}}" token="{{token}}" class="courses-item"></d2l-courses-card>
 			<paper-card class="calendar">
 				<button on-tap="_goToPage">Go to View1</button>
 			</paper-card>

--- a/src/my-app.html
+++ b/src/my-app.html
@@ -30,6 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="user/user-card.html">
 <link rel="import" href="search-results-page.html">
 <link rel="import" href="search/search-input.html">
+<link rel="import" href="courses/courses-drawer.html">
 
 <link rel="lazy-import" href="my-app-main-page.html">
 <link rel="lazy-import" href="my-login-page.html">
@@ -99,6 +100,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 			<app-drawer slot="drawer" id="drawer">
 				<div class="drawer-contents">
 					<a href="./" class="title">ParalleLMS</a>
+					<d2l-courses-drawer href="{{rootHref}}" token="{{token}}"></d2l-courses-drawer>
 				</div>
 			</app-drawer>
 			<app-header-layout>


### PR DESCRIPTION
Don't currently do anything. But they're _there_.

Also removed courses card from app-main-page (twas being used as a placeholder for the courses being in the sidebar, therefore, no longer needed!)