### PR TITLE
Updates-updates

### DIFF
--- a/src/discussions/discussions-forum-item.html
+++ b/src/discussions/discussions-forum-item.html
@@ -56,7 +56,7 @@
 
 			_changed(entity) {
 				this.forum = entity;
-				this.topics = entity.entities;
+				this.topics = entity.getSubEntitiesByClass('topic');
 			}
 
 			getHref(item) {

--- a/src/my-course-page.html
+++ b/src/my-course-page.html
@@ -12,6 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="activities/user-activity-usage-list.html">
 <link rel="import" href="awards/awards-card.html">
 <link rel="import" href="discussions/discussions-forum-list.html">
+<link rel="import" href="updates/updates-card.html">
 <link rel="import" href="shared-styles.html">
 <link rel="import" href="siren-entity.html">
 <link rel="import" href="siren-entity-mixin.html">
@@ -34,9 +35,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 		<d2l-siren-entity href="[[route.__queryParams.course]]" token="[[token]]" entity="{{organizationEntity}}"></d2l-siren-entity>
 
-		<d2l-awards-card href="[[awardsLink.href]]" token="{{token}}" class="card-item"></d2l-awards-card>
-		<d2l-user-activity-usage-list href="[[activitiesLink.href]]" token="{{token}}" class="card-item"></d2l-user-activity-usage-list>
-		<d2l-discussions-forum-list href="[[discussionsLink.href]]" token="{{token}}" class="card-item"></d2l-discussions-forum-list>
+		<d2l-siren-entity href="[[href]]" token="[[token]]" entity="{{rootEntity}}"></d2l-siren-entity>
+		<d2l-siren-entity href="[[userLink.href]]" token="[[token]]" entity="{{userEntity}}"></d2l-siren-entity>
+
+		<d2l-updates-card organization-filter="[[route.__queryParams.course]]" href="[[updatesLink.href]]" token="[[token]]" class="card-item"></d2l-updates-card>
+		<d2l-awards-card href="[[awardsLink.href]]" token="[[token]]" class="card-item"></d2l-awards-card>
+		<d2l-user-activity-usage-list href="[[activitiesLink.href]]" token="[[token]]" class="card-item"></d2l-user-activity-usage-list>
+		<d2l-discussions-forum-list href="[[discussionsLink.href]]" token="[[token]]" class="card-item"></d2l-discussions-forum-list>
 	</template>
 
 	<script>
@@ -59,6 +64,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 					discussionsLink: {
 						type: Object,
 						computed: '_getLinkByRel(organizationEntity, "https://api.brightspace.com/rels/discussions")'
+					},
+					rootEntity: Object,
+					userLink: {
+						type: Object,
+						computed: '_getLinkByRel(entity, "https://api.brightspace.com/rels/whoami")'
+					},
+					userEntity: Object,
+					updatesLink: {
+						type: Object,
+						computed: '_getLinkByRel(userEntity, "https://api.brightspace.com/rels/updates")'
 					}
 				};
 			}

--- a/src/updates/updates-card.html
+++ b/src/updates/updates-card.html
@@ -4,10 +4,11 @@
 <link rel="import" href="../../bower_components/paper-tabs/paper-tab.html">
 <link rel="import" href="../../bower_components/paper-tabs/paper-tabs.html">
 <link rel="import" href="../prefetch-mixin.html">
+<link rel="import" href="../shared-styles.html">
+<link rel="import" href="../siren-entity.html">
 <link rel="import" href="../siren-entity-mixin.html">
 <link rel="import" href="update-item.html">
 <link rel="import" href="update-item-grades.html">
-<link rel="import" href="../shared-styles.html">
 
 <dom-module id="d2l-updates-card">
 	<template>
@@ -17,6 +18,9 @@
 				width: 100%;
 			}
 		</style>
+
+		<d2l-siren-entity href="[[href]]" token="[[token]]" entity="{{updatesRootEntity}}"></d2l-siren-entity>
+		<d2l-siren-entity href="[[updatesFeedLink.href]]" token="[[token]]" entity="{{updatesFeedEntity}}"></d2l-siren-entity>
 
 		<paper-card class="medium-card-size">
 			<div class="card-header">
@@ -92,19 +96,25 @@
 					hasGrades: {
 						type: Boolean,
 						value: true
-					}
+					},
+					updatesRootEntity: Object,
+					updatesFeedLink: {
+						type: Object,
+						computed: '_getLinkByRel(entity, "feed")'
+					},
+					updatesFeedEntity: Object
 				};
 			}
 
 			static get observers() {
 				return [
-					'_changed(entity)'
+					'_changed(updatesFeedEntity)'
 				];
 			}
 
-			_changed(entity) {
-				this.newsUpdates = entity.getSubEntitiesByClass('news');
-				this.gradeUpdates = entity.getSubEntitiesByClass('grade');
+			_changed(updatesFeedEntity) {
+				this.newsUpdates = updatesFeedEntity.getSubEntitiesByClass('news');
+				this.gradeUpdates = updatesFeedEntity.getSubEntitiesByClass('grade');
 				this.hasUpdates = this.newsUpdates && this.newsUpdates.length > 0;
 				this.hasGrades = this.gradeUpdates && this.gradeUpdates.length > 0;
 			}

--- a/src/updates/updates-card.html
+++ b/src/updates/updates-card.html
@@ -14,8 +14,7 @@
 	<template>
 		<style include="shared-styles">
 			:host {
-				display: inline-block;
-				width: 100%;
+				display: block;
 			}
 		</style>
 
@@ -76,6 +75,7 @@
 
 			static get properties() {
 				return {
+					organizationFilter: String,
 					selected: {
 						type: Number,
 						value: 0
@@ -88,7 +88,6 @@
 						type: Array,
 						value: []
 					},
-					token: String,
 					hasUpdates: {
 						type: Boolean,
 						value: true
@@ -108,13 +107,33 @@
 
 			static get observers() {
 				return [
-					'_changed(updatesFeedEntity)'
+					'_changed(updatesFeedEntity, organizationFilter)'
 				];
 			}
 
-			_changed(updatesFeedEntity) {
-				this.newsUpdates = updatesFeedEntity.getSubEntitiesByClass('news');
-				this.gradeUpdates = updatesFeedEntity.getSubEntitiesByClass('grade');
+			_changed(updatesFeedEntity, organizationFilter) {
+				if (!updatesFeedEntity) {
+					return;
+				}
+
+				var newsEntities = updatesFeedEntity.getSubEntitiesByClass('news') || [];
+				var gradeEntities = updatesFeedEntity.getSubEntitiesByClass('grade') || [];
+
+				if (organizationFilter) {
+					newsEntities = newsEntities.filter(function(item) {
+						return item.links.some(function(link) {
+							return link.href === organizationFilter;
+						});
+					});
+					gradeEntities = gradeEntities.filter(function(item) {
+						return item.links.some(function(link) {
+							return link.href === organizationFilter;
+						});
+					});
+				}
+
+				this.newsUpdates = newsEntities;
+				this.gradeUpdates = gradeEntities;
 				this.hasUpdates = this.newsUpdates && this.newsUpdates.length > 0;
 				this.hasGrades = this.gradeUpdates && this.gradeUpdates.length > 0;
 			}


### PR DESCRIPTION
Adds the extra layer of fetching that was needed for the updates component to fetch things, then adds it to the course page. (The latter required adding the `organization-filter` property, as updates are retrieved across all organizations.)

Also fix a wee 🐛 in discussions so we only try to render topics, not start date entities. Which, apparently, forums can have.