### PR TITLE
Creating "See Notes for Resource Component"

### DIFF
--- a/src/notes/note-create.js
+++ b/src/notes/note-create.js
@@ -3,7 +3,6 @@ import { SirenEntityMixin } from '../siren-entity-mixin.js';
 import { SirenActionMixin } from '../siren-action-mixin.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import '@polymer/paper-input/paper-textarea.js';
-import '@polymer/paper-input/paper-input.js';
 import '@polymer/paper-button/paper-button.js';
 
 /* @mixes SirenEntityMixin

--- a/src/notes/note-create.js
+++ b/src/notes/note-create.js
@@ -4,6 +4,7 @@ import { SirenActionMixin } from '../siren-action-mixin.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import '@polymer/paper-input/paper-textarea.js';
 import '@polymer/paper-input/paper-input.js';
+import '@polymer/paper-button/paper-button.js';
 
 /* @mixes SirenEntityMixin
    @mixes SirenActionMixin */

--- a/src/notes/note-create.js
+++ b/src/notes/note-create.js
@@ -3,11 +3,11 @@ import { SirenEntityMixin } from '../siren-entity-mixin.js';
 import { SirenActionMixin } from '../siren-action-mixin.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import '@polymer/paper-input/paper-textarea.js';
-import '@polymer/paper-button/paper-button.js';
+import '@polymer/paper-input/paper-input.js';
 
 /* @mixes SirenEntityMixin
    @mixes SirenActionMixin */
-class AddNote extends SirenActionMixin(SirenEntityMixin(PolymerElement)) {
+class NoteCreate extends SirenActionMixin(SirenEntityMixin(PolymerElement)) {
 	static get template() {
 		return html`
 		<style>
@@ -31,18 +31,17 @@ class AddNote extends SirenActionMixin(SirenEntityMixin(PolymerElement)) {
 
         </style>
         <template is="dom-if" if="[[!showTextArea]]">
-            <paper-button style=""
-            class="add-note-button" on-tap="_toggleInput" id="loginButton">Take Note</paper-button>
+            <paper-button class="add-note-button" on-tap="_toggleInput">Take Note</paper-button>
         </template>
         <template is="dom-if" if="[[showTextArea]]">
             <paper-textarea label="Write a note"></paper-textarea>
-            <paper-button class="text-area-button" on-tap="_saveNote" id="loginButton">Save</paper-button>
-            <paper-button class="text-area-button" on-tap="_toggleInput" id="loginButton">Cancel</paper-button>
+            <paper-button class="text-area-button" on-tap="_saveNote">Save</paper-button>
+            <paper-button class="text-area-button" on-tap="_toggleInput">Cancel</paper-button>
         </template>
 `;
 	}
 
-	static get is() { return 'd2l-add-note'; }
+	static get is() { return 'd2l-note-create'; }
 
 	static get properties() {
 		return {
@@ -82,4 +81,4 @@ class AddNote extends SirenActionMixin(SirenEntityMixin(PolymerElement)) {
 	}
 }
 
-window.customElements.define(AddNote.is, AddNote);
+window.customElements.define(NoteCreate.is, NoteCreate);

--- a/src/notes/note.js
+++ b/src/notes/note.js
@@ -37,6 +37,7 @@ class Note extends LocalizationMixin(SirenActionMixin(SirenEntityMixin(PolymerEl
 	}
 
 	_changed(entity) {
+		if (!entity.properties) return
 		this.text = entity.properties.text;
 		this.date = this._formatDate(entity.getSubEntityByClass('create-date').properties.date, this.locale);
 	}

--- a/src/notes/note.js
+++ b/src/notes/note.js
@@ -37,7 +37,7 @@ class Note extends LocalizationMixin(SirenActionMixin(SirenEntityMixin(PolymerEl
 	}
 
 	_changed(entity) {
-		if (!entity.properties) return
+		if (!entity.properties) return;
 		this.text = entity.properties.text;
 		this.date = this._formatDate(entity.getSubEntityByClass('create-date').properties.date, this.locale);
 	}

--- a/src/notes/notes-by-resource.js
+++ b/src/notes/notes-by-resource.js
@@ -31,7 +31,7 @@ class NotesByResource extends SirenEntityMixin(PolymerElement) {
 
 	static get properties() {
 		return {
-            resourceLink: String,
+			resourceLink: String,
 			notes: Object,
 			showNotes: {
 				type: Boolean,
@@ -47,9 +47,9 @@ class NotesByResource extends SirenEntityMixin(PolymerElement) {
 	}
 
 	_changed(entity) {
-        if (!entity.properties) return
-        this.resourceLink = entity.getLinkByRel('self');
-        this.notes = entity.getSubEntitiesByRel('https://api.brightspace.com/rels/note');
+		if (!entity.properties) return;
+		this.resourceLink = entity.getLinkByRel('self');
+		this.notes = entity.getSubEntitiesByRel('https://api.brightspace.com/rels/note');
 	}
 
 	_showNotes() {

--- a/src/notes/notes-by-resource.js
+++ b/src/notes/notes-by-resource.js
@@ -1,0 +1,60 @@
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { SirenEntityMixin } from '../siren-entity-mixin.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import './note.js';
+import './notes-count.js';
+
+/* @mixes SirenEntityMixin
+   @mixes SirenActionMixin */
+class NotesByResource extends SirenEntityMixin(PolymerElement) {
+	static get template() {
+		return html`
+		<style>
+            :host {
+                display: block;
+            }
+        </style>
+		<d2l-notes-count on-tap="_showNotes" href="[[href]]" token="[[token]]"></d2l-notes-count>
+		<template is="dom-if" if="[[showNotes]]">
+			<ul>
+			<template is="dom-repeat" items="[[notes]]">
+				<li>
+					<d2l-note href="[[item.href]]" token="[[token]]"></d2l-note>
+				</li>
+			</template>
+			</ul>
+		</template>
+`;
+	}
+
+	static get is() { return 'd2l-notes-by-resource'; }
+
+	static get properties() {
+		return {
+            resourceLink: String,
+			notes: Object,
+			showNotes: {
+				type: Boolean,
+				value: false
+			}
+		};
+	}
+
+	static get observers() {
+		return [
+			'_changed(entity)'
+		];
+	}
+
+	_changed(entity) {
+        if (!entity.properties) return
+        this.resourceLink = entity.getLinkByRel('self');
+        this.notes = entity.getSubEntitiesByRel('https://api.brightspace.com/rels/note');
+	}
+
+	_showNotes() {
+		this.showNotes = true;
+	}
+}
+
+window.customElements.define(NotesByResource.is, NotesByResource);

--- a/src/notes/notes-count.js
+++ b/src/notes/notes-count.js
@@ -1,0 +1,41 @@
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { SirenEntityMixin } from '../siren-entity-mixin.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+
+/* @mixes SirenEntityMixin */
+class NotesCount extends SirenEntityMixin(PolymerElement) {
+	static get template() {
+		return html`
+		<style>
+            :host {
+                display: block;
+            }
+        </style>
+        Count: [[notesCount]]
+`;
+	}
+
+	static get is() { return 'd2l-notes-count'; }
+
+	static get properties() {
+		return {
+            notesCount: {
+                type: Number,
+                value: 0
+            }
+		};
+	}
+
+	static get observers() {
+		return [
+			'_changed(entity)'
+		];
+	}
+
+	_changed(entity) {
+        if (!entity.properties) return
+        this.notesCount = entity.properties.count;
+	}
+}
+
+window.customElements.define(NotesCount.is, NotesCount);

--- a/src/notes/notes-count.js
+++ b/src/notes/notes-count.js
@@ -19,10 +19,10 @@ class NotesCount extends SirenEntityMixin(PolymerElement) {
 
 	static get properties() {
 		return {
-            notesCount: {
-                type: Number,
-                value: 0
-            }
+			notesCount: {
+				type: Number,
+				value: 0
+			}
 		};
 	}
 
@@ -33,8 +33,8 @@ class NotesCount extends SirenEntityMixin(PolymerElement) {
 	}
 
 	_changed(entity) {
-        if (!entity.properties) return
-        this.notesCount = entity.properties.count;
+		if (!entity.properties) return;
+		this.notesCount = entity.properties.count;
 	}
 }
 


### PR DESCRIPTION
Trello: https://trello.com/c/GjBtaBUi/8-see-notes-on-this-resource-component
- Renamaing add Note to note create, cleaning up some bad Ids
- creating the notes by resource and count components
- Super simple design right now

Usage:
 d2l-notes-by-resource: 
 -  href: a link to a COLLECTION of notes
 - token: optional, decides what to show

d2l-notes-count:
 -  href: a link to a COLLECTION of notes
 - token: optional, decides what to show


Before Click:
![count](https://user-images.githubusercontent.com/14093568/41681096-8f0c771a-74a1-11e8-9d1c-0a5d3c48dd33.PNG)

After Click:
![afterclickcount](https://user-images.githubusercontent.com/14093568/41681126-a8c6e0a0-74a1-11e8-96f5-1ea6eb74bcb2.PNG)
