### PR TITLE
Removing unecessary resource link

### DIFF
--- a/src/notes/notes-by-resource.js
+++ b/src/notes/notes-by-resource.js
@@ -15,8 +15,8 @@ class NotesByResource extends SirenActionMixin(SirenEntityMixin(PolymerElement))
                 display: block;
             }
 		</style>
-		<d2l-notes-count on-tap="_showNotes" href="[[href]]" token="[[token]]"></d2l-notes-count>
-		<template is="dom-if" if="[[showNotes]]">
+		<d2l-notes-count on-tap="_toggleNotes" href="[[href]]" token="[[token]]"></d2l-notes-count>
+		<template is="dom-if" if="[[toggleNotes]]">
 			<ul>
 			<template is="dom-repeat" items="[[notes]]">
 				<li>
@@ -33,7 +33,7 @@ class NotesByResource extends SirenActionMixin(SirenEntityMixin(PolymerElement))
 	static get properties() {
 		return {
 			notes: Object,
-			showNotes: {
+			toggleNotes: {
 				type: Boolean,
 				value: false
 			}
@@ -51,8 +51,8 @@ class NotesByResource extends SirenActionMixin(SirenEntityMixin(PolymerElement))
 		this.notes = entity.getSubEntitiesByRel('https://api.brightspace.com/rels/note');
 	}
 
-	_showNotes() {
-		this.showNotes = !this.showNotes;
+	_toggleNotes() {
+		this.toggleNotes = !this.toggleNotes;
 	}
 }
 

--- a/src/notes/notes-by-resource.js
+++ b/src/notes/notes-by-resource.js
@@ -32,7 +32,6 @@ class NotesByResource extends SirenActionMixin(SirenEntityMixin(PolymerElement))
 
 	static get properties() {
 		return {
-			resourceLink: String,
 			notes: Object,
 			showNotes: {
 				type: Boolean,
@@ -49,12 +48,11 @@ class NotesByResource extends SirenActionMixin(SirenEntityMixin(PolymerElement))
 
 	_changed(entity) {
 		if (!entity.properties) return;
-		this.resourceLink = entity.getLinkByRel('self');
 		this.notes = entity.getSubEntitiesByRel('https://api.brightspace.com/rels/note');
 	}
 
 	_showNotes() {
-		this.showNotes = true;
+		this.showNotes = !this.showNotes;
 	}
 }
 

--- a/src/notes/notes-by-resource.js
+++ b/src/notes/notes-by-resource.js
@@ -16,7 +16,7 @@ class NotesByResource extends SirenActionMixin(SirenEntityMixin(PolymerElement))
             }
 		</style>
 		<d2l-notes-count on-tap="_toggleNotes" href="[[href]]" token="[[token]]"></d2l-notes-count>
-		<template is="dom-if" if="[[toggleNotes]]">
+		<template is="dom-if" if="[[showNotes]]">
 			<ul>
 			<template is="dom-repeat" items="[[notes]]">
 				<li>
@@ -33,7 +33,7 @@ class NotesByResource extends SirenActionMixin(SirenEntityMixin(PolymerElement))
 	static get properties() {
 		return {
 			notes: Object,
-			toggleNotes: {
+			showNotes: {
 				type: Boolean,
 				value: false
 			}
@@ -52,7 +52,7 @@ class NotesByResource extends SirenActionMixin(SirenEntityMixin(PolymerElement))
 	}
 
 	_toggleNotes() {
-		this.toggleNotes = !this.toggleNotes;
+		this.showNotes = !this.showNotes;
 	}
 }
 


### PR DESCRIPTION
- Allowing show notes to be toggle-able
- simplifying parameters to act like `d2l-notes-count`

Usage:
```
<d2l-notes-count href="https://notes.api.dev.brightspace.com/?search=&source=[[href]]"
token="[[token]]"></d2l-notes-count>

	<d2l-notes-by-resource href="https://notes.api.dev.brightspace.com/?search=&source=[[href]]"
			token="[[token]]"></d2l-notes-by-resource>```